### PR TITLE
Bump up version to v4.13.2

### DIFF
--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.upm-packages.moq",
   "displayName": "Moq",
-  "version": "4.13.1-2",
+  "version": "4.13.2",
   "unity": "2019.2",
   "description": "Moq for .NET 4.6",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
- UPM の枝番に関する扱いが変更になったため、パッチバージョンを上げる
- 本家とのバージョンのズレは目をつぶる